### PR TITLE
Fix URLs / regex and OSX compatibility

### DIFF
--- a/get-ip-ranges.sh
+++ b/get-ip-ranges.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-FIRSTLONGPART="https://download.microsoft.com/download/0/1/8/018E208D-54F8-44CD-AA26-CD7BC9524A8C/PublicIPs_"
-INITIALURL="http://www.microsoft.com/EN-US/DOWNLOAD/confirmation.aspx?id=41653"
-OUT="$(curl -s $INITIALURL | grep -o -P '(?<='$FIRSTLONGPART').*(?=.xml")' | tail -1)"
-wget -nv $FIRSTLONGPART$OUT".xml"
-cat "PublicIPs_"$OUT".xml"
-rm "PublicIPs_"$OUT".xml"
+set -e
+INITIALURL="https://www.microsoft.com/en-in/download/confirmation.aspx?id=41653"
+OUT=$(curl -s "${INITIALURL}" | grep -Eo '"https://[^"]*PublicIPs[^"]*"'|head -n 1|cut -d '"' -f 2)
+curl -s -f "${OUT}"


### PR DESCRIPTION
* Abort on script failsure
* Improved quoting
* Fixed regex to be similar to: https://gallery.technet.microsoft.com/scriptcenter/Adds-Azure-Datacenter-IP-dbeebe0c
* Use only curl, rather than curl and wget
* Drop temporary file usage. 